### PR TITLE
Fix crash on making certain torrent search queries

### DIFF
--- a/bot/modules/search.py
+++ b/bot/modules/search.py
@@ -205,10 +205,11 @@ class TorrentSearch:
         if (self.index != len(self.response_range) - 1):
             inline.append(nextBtn)
 
+        res_lim = min(self.RESULT_LIMIT, len(self.response) - self.RESULT_LIMIT*self.index)
         result = f"**Page - {self.index+1}**\n\n"
         result += "\n\n=======================\n\n".join(
             self.get_formatted_string(self.response[self.response_range[self.index]+i])
-            for i in range(self.RESULT_LIMIT)
+            for i in range(res_lim)
         )
 
         await self.message.edit(


### PR DESCRIPTION
Earlier , searching for torrents which had few results caused a crash . This fixes that issue 